### PR TITLE
a! as equivalent for analogWrite()?

### DIFF
--- a/src/app/arm-teensy3/app.fth
+++ b/src/app/arm-teensy3/app.fth
@@ -6,7 +6,7 @@ fl ../../lib/dl.fth
 #0 ccall: spins       { i.nspins -- }
 #1 ccall: wfi         { -- }
 #2 ccall: get-msecs   { -- n }
-#3 ccall: a!          { i.val -- }
+#3 ccall: a!          { i.val i.pin -- }
 #4 ccall: a@          { i.pin -- n }
 #5 ccall: p!          { i.val i.pin -- }
 #6 ccall: p@          { i.pin -- n }

--- a/src/platform/arm-teensy3/consoleio.c
+++ b/src/platform/arm-teensy3/consoleio.c
@@ -3,6 +3,10 @@
 #include "core_pins.h"
 #include "usb_serial.h"
 
+#define TIB_SIZE	255
+
+static unsigned char tib[TIB_SIZE + 1];
+static unsigned char *tib_ptr = tib, *first_chr_ptr = tib;
 
 char * ultoa(unsigned long val, char *buf, int radix)
 {
@@ -79,24 +83,75 @@ int kbhit()
   return 0;
 }
 
+static int char_push(unsigned char ch)
+{
+     // Never fail to push, but warn when it's the last push possible.
+     *(tib_ptr++) = ch;
+     if ((tib_ptr - tib) == TIB_SIZE)
+	  return 1;
+     else
+	  return 0;
+}
+
+static unsigned char char_pop(void)
+{
+     unsigned char ch = (char)0;
+     
+     // If there's a saved character in the TIB, return it.
+     if (first_chr_ptr < tib_ptr)
+	  ch = *(first_chr_ptr++);
+     // If we have read all of the characters out of the buffer, we can now reset both ptrs.
+     if (first_chr_ptr == tib_ptr)
+	  first_chr_ptr = tib_ptr = tib;
+     return ch;
+}
+
+static int char_peek(void)
+{
+     if (tib_ptr == tib)
+	  return 0;
+     return 1;
+}
+
+static unsigned char char_get(void)
+{
+     unsigned char c;
+	
+     if (sent_usb) {
+	  usb_serial_flush_output();
+	  sent_usb = 0;
+     }
+     if (UART0_RCFIFO > 0) {
+	  c = UART0_D;
+	  return c;
+     }
+     c = usb_serial_getchar();
+     if (c != -1) {
+	  seen_usb++;
+	  return c;
+     }
+}
+
 int getkey()
 {
-  int c;
-  if (sent_usb) {
-    usb_serial_flush_output();
-    sent_usb = 0;
-  }
-  while (1) {
-    if (UART0_RCFIFO > 0) {
-      c = UART0_D;
-      return c;
-    }
-    c = usb_serial_getchar();
-    if (c != -1) {
-      seen_usb++;
-      return c;
-    }
-  }
+     unsigned char ch;
+
+     // If there's a buffered character, return it immediately.
+     if (char_peek())
+	  return char_pop();
+     // Wait for a character to be available.
+     while (!kbhit())
+	  ;
+     // Always push the character because we don't know how many more there will be in the buffered sequence.
+     ch = char_get();
+     char_push(ch);
+     while (kbhit()) {
+	  // If our buffer fills up, char_push() returns true so we know to immediately stop buffering.
+	  ch = char_get();
+	  if (char_push(ch))
+	       return char_pop();
+     }
+     return char_pop();
 }
 
 void init_io(int argc, char **argv, cell *up)

--- a/src/platform/arm-teensy3/targets.mk
+++ b/src/platform/arm-teensy3/targets.mk
@@ -65,7 +65,7 @@ app.elf: $(PLAT_OBJS) $(FORTH_OBJS) tdate.o
 
 # This rule loads the hex file to the module
 burn: app.hex
-	./teensy_loader_cli -w -mmcu=mk20dx128 app.hex
+	teensy_loader_cli -w -mmcu=mk20dx128 app.hex
 
 # This rule builds a date stamp object that you can include in the image
 # if you wish.

--- a/src/platform/arm-teensy3/textend.c
+++ b/src/platform/arm-teensy3/textend.c
@@ -40,7 +40,7 @@ cell ((* const ccalls[])()) = {
     (cell (*)())spins,            // Entry # 0
     (cell (*)())wfi,              // Entry # 1
     (cell (*)())get_msecs,        // Entry # 2
-    (cell (*)())analogWriteDAC0,  // Entry # 3
+    (cell (*)())analogWrite,	  // Entry # 3
     (cell (*)())analogRead,       // Entry # 4
     (cell (*)())digitalWrite,     // Entry # 5
     (cell (*)())digitalRead,      // Entry # 6

--- a/src/platform/arm-teensy3/textend.c
+++ b/src/platform/arm-teensy3/textend.c
@@ -9,7 +9,7 @@
 cell get_msecs();
 cell wfi();
 cell spins();
-cell analogWriteDAC0();
+cell analogWrite();
 cell analogRead();
 cell digitalWrite();
 cell digitalRead();


### PR DESCRIPTION
Hi there,

Two small changes here in this pull request:
1. It seems to me like a! should be analogous to p! and m! - take both a pin and a value.  Currently, it's hard-wired to analogWriteDAC0().
2. The burn Makefile target erroneously assumes that the user has put the teensy_loader_cli command in the current directory, whereas it's built separately and usually will be on $PATH