### PR TITLE
For instructional purposes, it's becoming useful to actually have buffered I/O

### DIFF
--- a/build/arm-teensy3/Makefile
+++ b/build/arm-teensy3/Makefile
@@ -2,6 +2,9 @@
 
 TOPDIR=../..
 
+EXTRA_CLEAN += main.map	tdate.c app.hex version
+#DEFS += -DBUFFERED_CONSOLEIO
+
 include $(TOPDIR)/src/app/arm-teensy3/targets.mk
 
 default: app.elf app.hex app.nm app.dump

--- a/src/platform/arm-teensy3/consoleio.c
+++ b/src/platform/arm-teensy3/consoleio.c
@@ -3,6 +3,12 @@
 #include "core_pins.h"
 #include "usb_serial.h"
 
+#ifdef BUFFERED_CONSOLEIO
+#define TIB_SIZE	255
+
+static unsigned char tib[TIB_SIZE + 1];
+static unsigned char *tib_ptr = tib, *first_chr_ptr = tib;
+#endif /* BUFFERED_CONSOLEIO */
 
 char * ultoa(unsigned long val, char *buf, int radix)
 {
@@ -79,24 +85,83 @@ int kbhit()
   return 0;
 }
 
+#ifdef BUFFERED_CONSOLEIO
+static int char_push(unsigned char ch)
+{
+     // Never fail to push, but warn when it's the last push possible.
+     *(tib_ptr++) = ch;
+     if ((tib_ptr - tib) == TIB_SIZE)
+	  return 1;
+     else
+	  return 0;
+}
+
+static unsigned char char_pop(void)
+{
+     unsigned char ch = (char)0;
+     
+     // If there's a saved character in the TIB, return it.
+     if (first_chr_ptr < tib_ptr)
+	  ch = *(first_chr_ptr++);
+     // If we have read all of the characters out of the buffer, we can now reset both ptrs.
+     if (first_chr_ptr == tib_ptr)
+	  first_chr_ptr = tib_ptr = tib;
+     return ch;
+}
+
+static int char_peek(void)
+{
+     if (tib_ptr == tib)
+	  return 0;
+     return 1;
+}
+#endif /* BUFFERED_CONSOLEIO */
+
+static unsigned char char_get(void)
+{
+     unsigned char c;
+	
+     if (sent_usb) {
+	  usb_serial_flush_output();
+	  sent_usb = 0;
+     }
+     if (UART0_RCFIFO > 0) {
+	  c = UART0_D;
+	  return c;
+     }
+     c = usb_serial_getchar();
+     if (c != -1) {
+	  seen_usb++;
+	  return c;
+     }
+}
+
 int getkey()
 {
-  int c;
-  if (sent_usb) {
-    usb_serial_flush_output();
-    sent_usb = 0;
-  }
-  while (1) {
-    if (UART0_RCFIFO > 0) {
-      c = UART0_D;
-      return c;
-    }
-    c = usb_serial_getchar();
-    if (c != -1) {
-      seen_usb++;
-      return c;
-    }
-  }
+#ifndef BUFFERED_CONSOLEIO
+     while (!kbhit())
+          ;
+     return char_get();
+#else
+     unsigned char ch;
+
+     // If there's a buffered character, return it immediately.
+     if (char_peek())
+	  return char_pop();
+     // Wait for a character to be available.
+     while (!kbhit())
+	  ;
+     // Always push the character because we don't know how many more there will be in the buffered sequence.
+     ch = char_get();
+     char_push(ch);
+     while (kbhit()) {
+	  // If our buffer fills up, char_push() returns true so we know to immediately stop buffering.
+	  ch = char_get();
+	  if (char_push(ch))
+	       return char_pop();
+     }
+     return char_pop();
+#endif /* BUFFERED_CONSOLEIO */
 }
 
 void init_io(int argc, char **argv, cell *up)


### PR DESCRIPTION
I'm doing some forth training, and it's proving useful to be able to cut and paste (with echoing) examples into a forth session.  Without buffering, I cannot paste interactively, and nl does not display the characters it receives.  It's just not as seamless an experience.   I have conditionalized the code and also turned it off by default, so it's only something one would compile in for interactive demos.